### PR TITLE
Speed up card XML processing

### DIFF
--- a/hearthstone/cardxml.py
+++ b/hearthstone/cardxml.py
@@ -8,13 +8,13 @@ class CardXML(object):
 	def __init__(self, xml, locale="enUS"):
 		self.xml = xml
 		self.locale = locale
-		e = self.xml.findall("./Tag")
 		self.tags = {}
-		gametags = list(GameTag)
 		for e in self.xml.findall("./Tag"):
 			tag = int(e.attrib["enumID"])
-			if tag in gametags:
+			try:
 				tag = GameTag(tag)
+			except ValueError:
+				pass
 			self.tags[tag] = self._get_tag(e)
 
 		e = self.xml.findall("HeroPower")


### PR DESCRIPTION
The way tags were looked up was pretty inefficient: a longish list was
constructed for each card and then searched linearly. Instead, we can
just catch ValueError to handle unknown tag IDs.

Also removed unused iterator.