### PR TITLE
utils: Fix import lxml

### DIFF
--- a/hearthstone/utils.py
+++ b/hearthstone/utils.py
@@ -1,5 +1,5 @@
 try:
-	from lxml import ElementTree
+	from lxml import etree as ElementTree
 except ImportError:
 	from xml.etree import ElementTree
 from .enums import CardClass, Rarity


### PR DESCRIPTION
Without the try/except, you will see the real error. It misleads us that lxml has not been installed correctly, like [HearthSim/extract-scripts #15](https://github.com/HearthSim/extract-scripts/pull/15).

```
Traceback (most recent call last):
  File "process_cardxml.py", line 11, in <module>
    from hearthstone import cardxml
  File "/Users/zhong/Desktop/opensource/hssimenv/lib/python3.4/site-packages/hearthstone/cardxml.py", line 5, in <module>
    from .utils import ElementTree
  File "/Users/zhong/Desktop/opensource/hssimenv/lib/python3.4/site-packages/hearthstone/utils.py", line 1, in <module>
    from lxml import ElementTree
ImportError: cannot import name 'ElementTree'
```