### PR TITLE
Track initial controller to ensure correct initial_deck

### DIFF
--- a/hearthstone/entities.py
+++ b/hearthstone/entities.py
@@ -8,6 +8,7 @@ class Entity(object):
 		self.id = id
 		self.game = None
 		self.tags = {}
+		self._initial_controller = 0
 
 	def __repr__(self):
 		return "%s(id=%r, %s)" % (
@@ -20,6 +21,12 @@ class Entity(object):
 		return self.game.get_player(self.tags.get(GameTag.CONTROLLER, 0))
 
 	@property
+	def initial_controller(self):
+		return self.game.get_player(
+			self._initial_controller or self.tags.get(GameTag.CONTROLLER, 0)
+		)
+
+	@property
 	def type(self):
 		return self.tags.get(GameTag.CARDTYPE, CardType.INVALID)
 
@@ -28,6 +35,8 @@ class Entity(object):
 		return self.tags.get(GameTag.ZONE, Zone.INVALID)
 
 	def tag_change(self, tag, value):
+		if tag == GameTag.CONTROLLER and not self._initial_controller:
+			self._initial_controller = self.tags.get(GameTag.CONTROLLER, value)
 		self.tags[tag] = value
 
 
@@ -122,7 +131,7 @@ class Player(Entity):
 	@property
 	def initial_deck(self):
 		for entity in self.game.initial_entities:
-			if entity.controller != self:
+			if entity.initial_controller != self:
 				continue
 			# Exclude heroes and hero powers
 			if entity.tags.get(GameTag.CARDTYPE, 0) not in (

--- a/hearthstone/hslog/tests/test_main.py
+++ b/hearthstone/hslog/tests/test_main.py
@@ -47,6 +47,15 @@ D 02:59:14.6497780 GameState.DebugPrintPower() -         tag=ENTITY_ID value=3
 D 02:59:14.6500380 GameState.DebugPrintPower() -         tag=CARDTYPE value=PLAYER
 """.strip()
 
+FULL_ENTITY = """D 22:25:48.0678873 GameState.DebugPrintPower() - FULL_ENTITY - Creating ID=4 CardID=
+D 22:25:48.0678873 GameState.DebugPrintPower() -     tag=ZONE value=DECK
+D 22:25:48.0678873 GameState.DebugPrintPower() -     tag=CONTROLLER value=1
+D 22:25:48.0678873 GameState.DebugPrintPower() -     tag=ENTITY_ID value=4
+""".strip()
+
+CONTROLLER_CHANGE = """
+D 22:25:48.0708939 GameState.DebugPrintPower() - TAG_CHANGE Entity=4 tag=CONTROLLER value=2
+""".strip() 
 
 def test_create_empty_game():
 	parser = LogParser()
@@ -266,3 +275,28 @@ def test_tag_change_unknown_entity_format():
 	assert packet.entity == id
 	assert packet.tag == GameTag.ZONE
 	assert packet.value == Zone.HAND
+
+
+def test_initial_deck_initial_controller():
+	parser = LogParser()
+	parser.read(StringIO(INITIAL_GAME))
+	parser.read(StringIO(FULL_ENTITY))
+	parser.flush()
+	packet_tree = parser.games[0]
+	game = packet_tree.export().game
+
+	assert len(list(game.players[0].initial_deck)) == 1
+	assert len(list(game.players[1].initial_deck)) == 0
+
+	parser = LogParser()
+	parser.read(StringIO(INITIAL_GAME))
+	parser.read(StringIO(FULL_ENTITY))
+	parser.read(StringIO(CONTROLLER_CHANGE))
+	parser.flush()
+	packet_tree = parser.games[0]
+	game = packet_tree.export().game
+
+	assert len(list(game.players[0].initial_deck)) == 1
+	assert len(list(game.players[1].initial_deck)) == 0
+
+


### PR DESCRIPTION
This fixes an issue where player.initial_deck would consider the *current* controller, rather than the initial one, resulting in it containing stolen entities that were part of the opponents initial deck.