### PR TITLE
Avoiding Python 3.6 bug

### DIFF
--- a/hearthstone/utils.py
+++ b/hearthstone/utils.py
@@ -66,7 +66,7 @@ STANDARD_SETS = {
 
 
 ZODIAC_ROTATION_DATES = {
-	ZodiacYear.PRE_STANDARD: datetime.fromtimestamp(0),
+	ZodiacYear.PRE_STANDARD: datetime.fromtimestamp(86400),
 	ZodiacYear.KRAKEN: datetime(2016, 4, 26),
 	ZodiacYear.MAMMOTH: datetime(2017, 4, 7),
 }


### PR DESCRIPTION
Python 3.6 on Windows has a bug when timestamps below 86400 result in the following issue:
OSError: [Errno 22] Invalid argument

Bug details: https://bugs.python.org/issue29097