### PR TITLE
Add Quilboar to BATTLEGROUNDS_RACES

### DIFF
--- a/hearthstone/enums.py
+++ b/hearthstone/enums.py
@@ -1073,11 +1073,11 @@ VISIBLE_RACES = [
 ]
 
 # All minion types that may appear as a minion pool in Battlegrounds matches.
-# As of mid 2020 matches will always contain five of these. Some are guaranteed to appear
+# As of May 2021 matches will always contain five of these. Some are guaranteed to appear
 # in every match.
 BATTLEGROUNDS_RACES = [
 	Race.MURLOC, Race.DEMON, Race.MECHANICAL, Race.BEAST, Race.DRAGON,
-	Race.PIRATE, Race.ELEMENTAL,
+	Race.PIRATE, Race.ELEMENTAL, Race.QUILBOAR,
 ]
 
 


### PR DESCRIPTION
This is used by hsredshift's `battlegrounds_list_heroes_by_minion_types_bayes` to power the tribe selection on the Battlegrounds Hero List page. It should be merged as part of patch handling the 20.2 patch.